### PR TITLE
修复hostloc获取ip的API失效导致签到失败问题

### DIFF
--- a/ck_hostloc.py
+++ b/ck_hostloc.py
@@ -173,7 +173,7 @@ class HOSTLOC:
     # 打印输出当前ip地址
     @staticmethod
     def log_my_ip():
-        api_url = "https://api.ipify.org/"
+        api_url = "https://4.ipw.cn/"
         try:
             r = requests.get(url=api_url)
             r.raise_for_status()


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the issue causing sign-in failures by updating the API used to fetch the IP address.